### PR TITLE
harden: tighten path/origin checks and reject off-host redirects

### DIFF
--- a/bin/egov-law-mcp.mjs
+++ b/bin/egov-law-mcp.mjs
@@ -4,7 +4,10 @@ const SERVER_NAME = "egov-law-mcp";
 const SERVER_VERSION = "0.1.0";
 const PROTOCOL_VERSION = "2025-06-18";
 const EGOV_BASE_URL = "https://laws.e-gov.go.jp";
-const REQUEST_TIMEOUT_MS = Number.parseInt(process.env.EGOV_LAW_MCP_TIMEOUT_MS ?? "15000", 10);
+const REQUEST_TIMEOUT_MS = (() => {
+  const parsed = Number.parseInt(process.env.EGOV_LAW_MCP_TIMEOUT_MS ?? "15000", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15000;
+})();
 
 let lawListCache = null;
 let lawListFetchedAt = null;
@@ -157,18 +160,22 @@ function categoryToApiValue(category) {
 }
 
 async function fetchText(path) {
-  if (!path.startsWith("/api/1/")) {
+  if (!path.startsWith("/api/1/") || path.includes("..") || path.includes("//")) {
     throw new Error("Internal error: refused non-e-Gov API path");
+  }
+
+  const url = new URL(path, EGOV_BASE_URL);
+  if (url.origin !== EGOV_BASE_URL) {
+    throw new Error("Internal error: resolved URL escaped e-Gov origin");
   }
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  const url = `${EGOV_BASE_URL}${path}`;
 
   try {
     const response = await fetch(url, {
       method: "GET",
-      redirect: "follow",
+      redirect: "error",
       signal: controller.signal,
       headers: {
         "User-Agent": `${SERVER_NAME}/${SERVER_VERSION} (https://codeagent.jp/)`,


### PR DESCRIPTION
## Summary
- Defense-in-depth tightening of `fetchText` so SSRF surface is provably zero even if e-Gov changes its redirect behavior.
- Reject paths containing `..` or `//`, then re-verify origin via `new URL(path, EGOV_BASE_URL)` before issuing fetch.
- Set fetch `redirect: "error"` so an off-origin redirect from e-Gov fails fast instead of being silently followed.
- Validate `EGOV_LAW_MCP_TIMEOUT_MS` (must parse as a positive finite number, otherwise fall back to 15000).

None of these are exploitable today — the host is hardcoded and all dynamic input is `encodeURIComponent`'d — so this is purely belt-and-suspenders.

## Test plan
- [x] `node --check bin/egov-law-mcp.mjs` passes
- [x] `initialize` + `tools/list` over stdio returns expected payloads
- [x] `tools/call` `search_laws` against live e-Gov returns results (`個人情報`, limit 2)
- [ ] Reviewer sanity-checks the diff