### PR TITLE
build: add Dockerfile for Glama listing checks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+node_modules
+*.log
+.env
+.DS_Store
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+COPY bin ./bin
+
+RUN chmod +x bin/egov-law-mcp.mjs
+
+ENTRYPOINT ["node", "bin/egov-law-mcp.mjs"]


### PR DESCRIPTION
## Summary
- Add a minimal `Dockerfile` (and `.dockerignore`) so [glama.ai](https://glama.ai/mcp/servers) can build and introspect the server as part of the awesome-mcp-servers listing gate ([upstream PR #5359](https://github.com/punkpeye/awesome-mcp-servers/pull/5359)).
- Base image `node:20-alpine` matches `engines.node: ">=20.0.0"`.
- Zero runtime deps in `package.json`, so no `npm install` step — just copy `bin/` and exec.
- `ENTRYPOINT ["node", "bin/egov-law-mcp.mjs"]` keeps `docker run -i <image>` as a drop-in MCP stdio transport.

## Test plan
- [ ] `docker build -t egov-law-mcp .` succeeds (no local Docker on author machine — Glama will validate)
- [ ] `docker run -i egov-law-mcp` accepts an `initialize` + `tools/list` JSON-RPC pair on stdin and returns the four tools
- [ ] Glama listing build passes